### PR TITLE
Update EstimizeReleaseDataDownloader.cs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    container:
-        image: quantconnect/lean:foundation
+    runs-on: ubuntu-20.04    
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Free space
+        run: df -h && sudo rm -rf /usr/local/lib/android && sudo rm -rf /opt/ghc && rm -rf /opt/hostedtoolcache* && df -h
+
+      - name: Pull Foundation Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quantconnect/lean:foundation
 
       - name: BuildDataSource
         run: dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1

--- a/DataProcessing/EstimizeReleaseDataDownloader.cs
+++ b/DataProcessing/EstimizeReleaseDataDownloader.cs
@@ -122,7 +122,6 @@ namespace QuantConnect.DataProcessing
                                     // data and make backtests non-deterministic. We want to have
                                     // consistency with our data in live trading historical requests as well
                                     var releases = JsonConvert.DeserializeObject<List<EstimizeRelease>>(result, JsonSerializerSettings)
-                                        .Where(x => x.Eps != null)
                                         .GroupBy(x =>
                                         {
                                             var normalizedTicker = NormalizeTicker(ticker);

--- a/tests/EstimizeTests.cs
+++ b/tests/EstimizeTests.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.DataLibrary.Tests
     {
         private static IDataProvider EstimizeDataProvider = new DefaultDataProvider();
         private static IMapFileProvider _mapFileProvider;
-        private static Symbol SymbolAAPL = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
+        private static Symbol SymbolAAPL => Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
         private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings
         {
@@ -169,7 +169,7 @@ namespace QuantConnect.DataLibrary.Tests
             var data = new EstimizeRelease();
             var date = new DateTime(2019, 6, 10);
             var source = data.GetSource(config, date, false);
-            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data, EstimizeDataProvider);
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data, EstimizeDataProvider, null);
 
             var rows = factory.Read(source).ToList();
 
@@ -253,7 +253,7 @@ namespace QuantConnect.DataLibrary.Tests
             var data = new EstimizeEstimate();
             var date = new DateTime(2019, 6, 10);
             var source = data.GetSource(config, date, false);
-            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data, EstimizeDataProvider);
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data, EstimizeDataProvider, null);
 
             var rows = factory.Read(source).ToList();
 
@@ -280,7 +280,7 @@ namespace QuantConnect.DataLibrary.Tests
             var data = new EstimizeConsensus();
             var date = new DateTime(2019, 6, 10);
             var source = data.GetSource(config, date, false);
-            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data, EstimizeDataProvider);
+            var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, false, data, EstimizeDataProvider, null);
 
             var rows = factory.Read(source).ToList();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Updating the EstimizeReleaseDataDownloader to include all the consensus by removing the eps equal to Null check.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We had an eps check for null inside EstimizeReleaseDataDownloader which did not process consensus after the last release. Removing this check to process all the consensus data that is updated every day.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running algorithms in QC Cloud.
For example AAPL:
Previously we did not have any data points for consensus on the cloud before 20240502 (date of last release). After the data upload with the new script we have concensus data till today

Red:
![image](https://github.com/user-attachments/assets/9c637754-b13a-4bac-9a6a-f4ad411b6a9e)

Green:
![image](https://github.com/user-attachments/assets/d5955bc3-9809-4363-b1b5-42ad5dbf3660)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->